### PR TITLE
Unversion GPC links / Add GPC JWT warning message

### DIFF
--- a/pages/design/integration_example_gpconnect.md
+++ b/pages/design/integration_example_gpconnect.md
@@ -13,9 +13,9 @@ The full details of the GP Connect APIs can be found in the [GP Connect API Spec
 
 GP Connect provider APIs are accessed through the NHS Spine. As such, consumers of GP Connect APIs are required to integrate with the following Spine services as a pre-requisite to making API calls to GP Connect provider APIs:
 
-- [Personal Demographics Service (PDS)](https://developer.nhs.uk/apis/gpconnect-1-2-0/integration_personal_demographic_service.html)
-- [Spine Directory Service (SDS)](https://developer.nhs.uk/apis/gpconnect-1-2-0/integration_spine_directory_service.html)
-- [Spine Secure Proxy (SSP)](https://developer.nhs.uk/apis/gpconnect-1-2-0/integration_spine_secure_proxy.html)
+- [Personal Demographics Service (PDS)](https://developer.nhs.uk/apis/gpconnect/integration_personal_demographic_service.html)
+- [Spine Directory Service (SDS)](https://developer.nhs.uk/apis/gpconnect/integration_spine_directory_service.html)
+- [Spine Secure Proxy (SSP)](https://developer.nhs.uk/apis/gpconnect/integration_spine_secure_proxy.html)
 
 To illustrate this, an example is given below of all the steps required consume GP Connect capabilities. For full details, please refer to the relevant spine service pages.
 
@@ -30,32 +30,32 @@ The steps shown in the diagram are detailed below.
 | Step | Description |
 |------|-------------|
 |      | *Step 1 is optional in the sense that a cached version of a previous these trace results may be available to the consumer.* |    
-| 1a   | **Consumer** is responsible for performing a  [Personal Demographics Service(PDS)](https://developer.nhs.uk/apis/gpconnect-1-2-0/integration_personal_demographic_service.html) Trace to both verify the NHS Number and obtain the ODS code of the GP Practice system. |
+| 1a   | **Consumer** is responsible for performing a  [Personal Demographics Service(PDS)](https://developer.nhs.uk/apis/gpconnect/integration_personal_demographic_service.html) Trace to both verify the NHS Number and obtain the ODS code of the GP Practice system. |
 | 1b   | **PDS** returns NHS Number verification status, and the ODS code of the GP Practice system. |
 |      |      |
 |      | *Step 2 is optional in the sense that cached or configured endpoint details for the Practice may be available from a previous SDS interaction.* |    
-| 2a   | **Consumer** calls [Spine Directory Service (SDS)]((https://developer.nhs.uk/apis/gpconnect-1-2-0/integration_spine_directory_service.html) to discover the Accredited System ID (ASID) of the system which provides a FHIR endpoint at the practice identified by the specified ODS code. |
+| 2a   | **Consumer** calls [Spine Directory Service (SDS)]((https://developer.nhs.uk/apis/gpconnect/integration_spine_directory_service.html) to discover the Accredited System ID (ASID) of the system which provides a FHIR endpoint at the practice identified by the specified ODS code. |
 | 2b   | **SDS** returns the ASID. | 
 | 2c   | **Consumer** calls Spine Directory Service again to discover the URL of the FHIR server endpoint at the practice | 
 | 2d   | **SDS** returns details of the FHIR endpoint. | 
 |      |      |
 |      | *Step 3 is optional in the sense that the Capability Statement may be used to verify the FHIR capabilities which the endpoint provides should this be required at run time. The results of this call may be cached for future interactions.* |    
-| 3a   | **Consumer** calls the [metadata endpoint](https://developer.nhs.uk/apis/gpconnect-1-2-0/foundations_use_case_get_the_fhir_capability_statement.html){:target="_blank"} at the practice FHIR server to request full details of which FHIR operations are implemented at that server - the Capability Statement. |
+| 3a   | **Consumer** calls the [metadata endpoint](https://developer.nhs.uk/apis/gpconnect/foundations_use_case_get_the_fhir_capability_statement.html){:target="_blank"} at the practice FHIR server to request full details of which FHIR operations are implemented at that server - the Capability Statement. |
 | 3b   | **Spine Security Proxy (SSP)** receives the call from the Consumer, performs security checks, and if these pass, forwards the consumer request to the provider. |
 | 3c   | **Provider** returns the Capability Statement to the SSP. |
 | 3d   | **SSP** forwards the Capability Statement received from the Provider to the Consumer. |
 |      |      |
-| 4a   | **Consumer** then makes an API call to [Search for free slots](https://developer.nhs.uk/apis/gpconnect-1-2-0/appointments_use_case_search_for_free_slots.html){:target="_blank"} at the practice in the specified time-frame. |
+| 4a   | **Consumer** then makes an API call to [Search for free slots](https://developer.nhs.uk/apis/gpconnect/appointments_use_case_search_for_free_slots.html){:target="_blank"} at the practice in the specified time-frame. |
 | 4b   | **SSP** forwards the call from the Consumer, performs security checks, and if these pass, forwards the consumer request to the provider. |
-| 4c   | **Provider** responds with details of what slots are available for booking. Should no applicable slots be returned, the consumer may make repeated calls to [Search for free slots](https://developer.nhs.uk/apis/gpconnect-1-2-0/appointments_use_case_search_for_free_slots.html){:target="_blank"} with amended date ranges. |
+| 4c   | **Provider** responds with details of what slots are available for booking. Should no applicable slots be returned, the consumer may make repeated calls to [Search for free slots](https://developer.nhs.uk/apis/gpconnect/appointments_use_case_search_for_free_slots.html){:target="_blank"} with amended date ranges. |
 | 4d   | **SSP** forwards the free slots received from the Provider to the Consumer. |   
 |      |      |
-| 5a   | **Consumer** makes API call to [Find a patient](https://developer.nhs.uk/apis/gpconnect-1-2-0/foundations_use_case_find_a_patient.html){:target="_blank"} providing the patient's NHS Number. |
+| 5a   | **Consumer** makes API call to [Find a patient](https://developer.nhs.uk/apis/gpconnect/foundations_use_case_find_a_patient.html){:target="_blank"} providing the patient's NHS Number. |
 | 5b   | **Spine Security Proxy (SSP)** receives the call from the Consumer, performs security checks, and if these pass, forwards the consumer request to the provider. |
-| 5c   | **Provider** finds patient record and returns the logical identifier of the patient record at this practice in their system. See [Patient record not present](https://developer.nhs.uk/apis/gpconnect-1-2-0/appointments_consumer_sessions.html#consumer-session---booking-an-appointment---no-patient-record){:target="_blank"} for an illustration of the steps required in this case. |
+| 5c   | **Provider** finds patient record and returns the logical identifier of the patient record at this practice in their system. See [Patient record not present](https://developer.nhs.uk/apis/gpconnect/appointments_consumer_sessions.html#consumer-session---booking-an-appointment---no-patient-record){:target="_blank"} for an illustration of the steps required in this case. |
 | 5d   | **SSP** forwards the Patient details received from the Provider to the Consumer |
 |      |      |
-| 6a   | **Consumer** calls [Book an appointment](https://developer.nhs.uk/apis/gpconnect-1-2-0/appointments_use_case_book_an_appointment.html){:target="_blank"} indicating the slots selected in the UI together with the logical ID of the patient. |
+| 6a   | **Consumer** calls [Book an appointment](https://developer.nhs.uk/apis/gpconnect/appointments_use_case_book_an_appointment.html){:target="_blank"} indicating the slots selected in the UI together with the logical ID of the patient. |
 | 6b   | **Spine Security Proxy (SSP)** forwards the call from the Consumer, performs security checks, and if these pass, forwards the consumer request to the provider. |
 | 6c   | **Provider** responds with details of the booked appointment as confirmation of success. |
 | 6d   | **SSP** forwards the Appointment details received from the Provider to the Consumer. |

--- a/pages/design/security_jwt.md
+++ b/pages/design/security_jwt.md
@@ -7,6 +7,8 @@ permalink: security_jwt.html
 summary: "Overview of how authorisation information is used and passed in APIs for audit and provenance."
 ---
 
+{% include important.html content="For instructions on constructing a JSON Web Token for **GP Connect** please see [Cross organisation audit and provenance](https://developer.nhs.uk/apis/gpconnect/integration_cross_organisation_audit_and_provenance.html) in the GP Connect specification." %}
+
 ## Use of Bearer Tokens ###
 
 An output of [authorising access](security_authorisation.html) to an API is the provision of a JSON Web Token. This MUST be passed in the API calls to ensure the systems being called are able to verify that the user has been authorised to see the resources requested. This JWT is also used for audit purposes, so the API implementation (and the SSP in the case of a call brokered through that service) can record the user context in it's audit trail.

--- a/pages/design/ssp_implementation_guide.md
+++ b/pages/design/ssp_implementation_guide.md
@@ -147,7 +147,7 @@ The inclusion of the consumer systems UserID, user name and date/time of the eve
   
 <sup>3</sup> a table of `InteractionIDs` for each RESTful API can be found in the [Development - FHIR API Guidance - Operation Guidance](development_fhir_operation_guidance.html) page.
 
-<sup>4</sup> an example of a valid JSON Web Token (JWT) for the purposes of GP Connect can be found in the [Access Tokens and Audit](https://developer.nhs.uk/apis/gpconnect-1-2-0/integration_cross_organisation_audit_and_provenance.html#jwt-payload-example) guidance.
+<sup>4</sup> an example of a valid JSON Web Token (JWT) for the purposes of GP Connect can be found in the [Access Tokens and Audit](https://developer.nhs.uk/apis/gpconnect/integration_cross_organisation_audit_and_provenance.html#jwt-payload-example) guidance.
 
 {% include important.html content="Note that according to [RFC 7230, section 3.2](https://tools.ietf.org/html/rfc7230) all HTTP header fields names are case insensitive and should be handled as such." %}
 
@@ -252,7 +252,7 @@ The inclusion of the consumer systems UserID, user name and date/time of the eve
 - Request and response HTTP payloads SHALL NOT be modified, as this would require the proxy to have detained knowledge of payload structure and transport encoding. Furthermore, payload modification may introduce problems with asserting digital signatures/payload provenance in the future.
 - Request and response HTTP headers SHALL NOT be modified.
 - The proxy SHOULD validate and SHALL log for audit purposes user and system claims provided in the HTTP authorization header as an oAuth bearer token (as outlined in [RFC 6749](https://tools.ietf.org/html/rfc6749)) in the form of a JSON Web Token (JWT) as defined in [RFC 7519](https://tools.ietf.org/html/rfc7519).
-	- Refer to the [Access Tokens and Audit](security_jwt.html) implementation guidance for full details. GP Connect consumers should refer to [GP Connect - Cross organisation audit and provenance](https://developer.nhs.uk/apis/gpconnect-1-2-0/integration_cross_organisation_audit_and_provenance.html)
+	- Refer to the [Access Tokens and Audit](security_jwt.html) implementation guidance for full details. GP Connect consumers should refer to [GP Connect - Cross organisation audit and provenance](https://developer.nhs.uk/apis/gpconnect/integration_cross_organisation_audit_and_provenance.html)
 - Additional request and response HTTP Headers SHOULD be added into the HTTP request/response for the purposes of security/auditing and debugging/profiling purposes.
 - Additional HTTP response headers SHALL be added into the HTTP response for the purpose of throttling/rate limiting API access.
 - As outlined in [RFC 6585](http://tools.ietf.org/html/rfc6585) HTTP status code 429 SHALL be used to notify consumer systems that their throttling limit has been reached or that the server is experiencing a DoS attack.

--- a/pages/design/ssp_providers.md
+++ b/pages/design/ssp_providers.md
@@ -19,7 +19,7 @@ In order to ensure that endpoint lookup is reliable, the following guidelines mu
 
 ### 1. Format of Server Root URL
 
-The *Server Root URL* for a given ASID SHALL be defined in the nhsMhsEndPoint attribute of the MHS record (i.e. the ldap object of type nhsMhs). For GP Connect endpoints this URL SHALL be in the format described in the GP Connect [API Versioning](https://developer.nhs.uk/apis/gpconnect-1-2-0/development_general_api_guidance.html#service-root-url-versioning) guidance.
+The *Server Root URL* for a given ASID SHALL be defined in the nhsMhsEndPoint attribute of the MHS record (i.e. the ldap object of type nhsMhs). For GP Connect endpoints this URL SHALL be in the format described in the GP Connect [API Versioning](https://developer.nhs.uk/apis/gpconnect/development_general_api_guidance.html#service-root-url-versioning) guidance.
 
 
 ### 2. For First of Type interactions, CMA type endpoints only will be used
@@ -41,7 +41,7 @@ In line with this, provider systems SHOULD perform checks that the FHIR request 
 
 ### 4. Practice routing identifier to be included in FHIR Server Root URL
 
-For GP Connect APIs, as described in the GP Connect [API Versioning](https://developer.nhs.uk/apis/gpconnect-1-2-0/development_general_api_guidance.html#service-root-url-versioning) guidance, a routing identifier SHALL be placed in the FHIR Servder Root URL. This routing identifier may be the ODS code of the practice, or another logical identifier which acheives reliable routing of the request to the patient's registered practice data store. It is expected that the FHIR server business logic will extract the routing identifier.
+For GP Connect APIs, as described in the GP Connect [API Versioning](https://developer.nhs.uk/apis/gpconnect/development_general_api_guidance.html#service-root-url-versioning) guidance, a routing identifier SHALL be placed in the FHIR Servder Root URL. This routing identifier may be the ODS code of the practice, or another logical identifier which acheives reliable routing of the request to the patient's registered practice data store. It is expected that the FHIR server business logic will extract the routing identifier.
 
 In line with this, HTTP headers SHALL NOT be used to provide this organisation routing.
 
@@ -52,14 +52,14 @@ ODS codes which refer to Principle Clinical Systems as a single entity SHALL NOT
 
 ### 6. The FHIR Server Root URL SHALL contain the FHIR version name
 
-For GP Connect APIs, the FHIR Server Root URL defined in the nhsMhsEndPoint attribute SHALL contain the FHIR version name as described in the GP Connect [API Versioning](https://developer.nhs.uk/apis/gpconnect-1-2-0/development_general_api_guidance.html#service-root-url-versioning) guidance. This will enable versioning of provider API by FHIR version. 
+For GP Connect APIs, the FHIR Server Root URL defined in the nhsMhsEndPoint attribute SHALL contain the FHIR version name as described in the GP Connect [API Versioning](https://developer.nhs.uk/apis/gpconnect/development_general_api_guidance.html#service-root-url-versioning) guidance. This will enable versioning of provider API by FHIR version. 
 
 In line with this, provider systems SHALL NOT version through the use of HTTP headers.
 
 
 ### 7. FHIR version SHALL match version found in FHIR conformance statement
 
-The FHIR version as returned in a [CapabilityStatement](api_foundation_capabilitystatement.html) from the FHIR server which services the FHIR request SHALL match the FHIR version given in the FHIR Server Root URL. Details of how to retrieve this for GP Connect FHIR servers can be found at [GP Connect - Get the FHIR capability statement](https://developer.nhs.uk/apis/gpconnect-1-2-0/foundations_use_case_get_the_fhir_capability_statement.html)
+The FHIR version as returned in a [CapabilityStatement](api_foundation_capabilitystatement.html) from the FHIR server which services the FHIR request SHALL match the FHIR version given in the FHIR Server Root URL. Details of how to retrieve this for GP Connect FHIR servers can be found at [GP Connect - Get the FHIR capability statement](https://developer.nhs.uk/apis/gpconnect/foundations_use_case_get_the_fhir_capability_statement.html)
 
 ### 8. FHIR Server Root URLs associated with a given product set SHALL use same FHIR Version
 


### PR DESCRIPTION
Change 1:  GP Connect specification links are now unversioned
Change 2:  Add warning note to JWT page - "For instructions on constructing a JSON Web Token for **GP Connect** please see [Cross organisation audit and provenance] in the GP Connect specification.